### PR TITLE
make shortcut configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "shortcut": "Ctrl+H"
+}

--- a/showHtml.py
+++ b/showHtml.py
@@ -13,6 +13,13 @@ import cgi
 import anki.notes
 
 
+def gc(arg, fail=False):
+    conf = mw.addonManager.getConfig(__name__)
+    if conf:
+        return conf.get(arg, fail)
+    else:
+        return fail
+
 def HTML(nids):
     """Show each field's content, and the note id. Click on cancel to stop seeing ids"""
     for nid in nids:
@@ -26,7 +33,7 @@ def HTML(nids):
 
 def setupMenu(browser):
     a = QAction("Note's HTML", browser)
-    a.setShortcut(QKeySequence("Ctrl+H")) # Shortcut for convenience. Added by Didi
+    a.setShortcut(QKeySequence(gc("shortcut", "Ctrl+H")))
     a.triggered.connect(lambda e: onHTML(browser))
     browser.form.menuEdit.addSeparator()
     browser.form.menuEdit.addAction(a)


### PR DESCRIPTION
"Ctrl+H" is an easy-to-use shortcut so maybe a user wants it for another add-on. Also when I'm grepping the add-ons I have downloaded some others use "Ctrl+H" (though I didn't check if they are in the browser or editor).

I mainly made this pull request because I want to use "ctrl+h" as a default in my [Browser Search Box: Quick Insert Tag, Deck, Notetype](https://ankiweb.net/shared/info/1052724801) and noticed that it didn't work in my default profile which has your "anki-show-html".

and once more sorry for the trouble with the other opened, then closed pull request of mine.

P.S. (not related to my pull request): My impression is that [this commit](https://github.com/Arthur-Milchior/anki-show-html/commit/1b8f00c8bfdf4af3d18a838b437679ccefe5ec3c) doesn't fit into the readme of this add-on?